### PR TITLE
Merge Neptune styles into Poseidon

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "build": "git push --set-upstream origin main",
+    "build": "git pull origin merge-neptune-styles --rebase",
     "test": "git push --set-upstream origin main"
   }
 }

--- a/core/toolbar/navbar.css
+++ b/core/toolbar/navbar.css
@@ -40,3 +40,43 @@
 #nav-bar.browser-toolbar .toolbarbutton-icon { &:-moz-window-inactive {opacity: 0.5 !important;} }
 #titlebar .titlebar-buttonbox-container .titlebar-buttonbox { &:-moz-window-inactive {opacity: 0.5 !important;} }
 #nav-bar.browser-toolbar #urlbar-container { &:-moz-window-inactive {opacity: 0.5 !important;} }
+
+/*---------- Navbar ----------*/
+#nav-bar {
+		grid-area: 1 / 1 / span 1 / span 1;
+		width: fit-content;
+		background-color: transparent !important;
+		padding: var(--theme-browser-toolbox-padding) 0 var(--theme-browser-toolbox-padding) calc(92px - var(--toolbar-start-end-padding) / 2) !important;
+		border: none !important;
+
+		> .customization-target:not(#widget-overflow-fixed-list) {
+			> toolbarpaletteitem[place=toolbar][id^=wrapper-customizableui-special-spring], toolbarspring {
+				max-width: 100% !important;
+
+				#nav-bar & {
+					flex-grow: 400 !important;
+				}
+			}
+
+			 > toolbarpaletteitem[place="toolbar"] > toolbarspring {
+				margin-block: 0 !important;
+			}
+
+			:root[customizing] & {
+				animation: emeTeachingMoment 1s linear infinite;
+			}
+		}
+
+		:root[inFullscreen] & {
+			padding-inline-start: var(--toolbar-start-end-padding) !important;
+		}
+
+		:is(#reload-button, #stop-button) > .toolbarbutton-animatable-box > .toolbarbutton-animatable-image {
+			animation-duration: 0s !important;
+		}
+
+		@media (-moz-bool-pref: "sidebar.verticalTabs") {
+			grid-column: 1 / span 2;
+			width: auto;
+		}
+	}

--- a/core/toolbar/urlbar.css
+++ b/core/toolbar/urlbar.css
@@ -259,3 +259,381 @@
     }
   }
 }
+
+/*---------- Urlbar ----------*/
+#urlbar-container {
+	width: max(320px, 28em) !important;
+	padding: 0 !important;
+}
+
+#search-container {
+	flex-grow: 100 !important;
+	padding: 0 !important;
+}
+
+#searchbar,
+#urlbar-background {
+	background-color: var(--neptune-urlbar-background) !important;
+	border: none !important;
+	border-radius: var(--border-radius-small) !important;
+	box-shadow: none !important;
+	transition: background-color .2s ease;
+
+	@media (-moz-bool-pref: "sidebar.verticalTabs") {
+		background: none !important;
+		border: 1px solid var(--neptune-toolbar-border-color) !important;
+	}
+}
+
+#urlbar {
+	height: var(--urlbar-height) !important;
+	width: var(--urlbar-width) !important;
+	margin: 0 !important;
+	font-size: 12.5px !important;
+
+	> .urlbar-input-container {
+		padding: 0 !important;
+		border: none !important;
+		border-radius: var(--border-radius-small) !important;
+
+		@media (-moz-bool-pref: "sidebar.verticalTabs") {
+			> .urlbar-input-box > .urlbar-input {
+				text-align: center !important;
+
+				#urlbar:is([focused], [open]) & {
+					text-align: revert !important;
+				}
+			}
+		}
+
+		> #urlbar-search-mode-indicator {
+			margin-inline: 0 !important;
+			padding-inline: var(--urlbar-icon-padding) !important;
+			font-size: 10.5px;
+		}
+
+		> #urlbar-searchmode-switcher {
+			margin-inline: 0 !important;
+
+			&[open] {
+				background-color: var(--neptune-item-active-background) !important;
+			}
+		}
+
+		> #searchmode-switcher-chicklet {
+			margin-inline: 0 !important;
+			font-size: 10.5px;
+
+			> #searchmode-switcher-close {
+				margin-inline: var(--urlbar-icon-padding) !important;
+			}
+		}
+	}
+
+	@media not (-moz-bool-pref: "sidebar.verticalTabs") {
+		&:hover > #urlbar-background {
+			background-color: var(--neptune-urlbar-hover-background) !important;
+		}
+	}
+
+	&:is([focused], [open]) > #urlbar-background {
+		background-color: var(--neptune-urlbar-focused-background) !important;
+
+		@media (-moz-bool-pref: "sidebar.verticalTabs") {
+			background-color: var(--neptune-verticaltab-background) !important;
+		}
+	}
+}
+
+.urlbarView {
+	color-scheme: light dark;
+	width: calc(100% + 16px) !important;
+	margin: 5px 0 0 -8px !important;
+	border: none !important;
+	border-radius: calc(var(--border-radius-medium) + 2px);
+	background-color: var(--theme-menupopup-background);
+	color: MenuText;
+	box-shadow: var(--neptune-small-shadow), var(--neptune-menu-shadow) !important;
+
+	> .urlbarView-body-outer > .urlbarView-body-inner {
+		width: inherit !important;
+		margin-inline: 0 !important;
+		border: none !important;
+	}
+}
+
+.urlbarView-results {
+	padding: var(--urlbarView-item-block-padding) !important;
+
+	> .urlbarView-row {
+		border: var(--button-border) !important;
+
+		> .urlbarView-row-inner {
+			flex-wrap: nowrap !important;
+			align-items: center !important;
+			padding: 0 !important;
+
+			> .urlbarView-no-wrap {
+				flex-basis: revert !important;
+			}
+
+			.urlbarView-title {
+				line-height: 1.28 !important;
+			}
+
+			:is(.urlbarView-overflowable, .urlbarView-url)[overflow] {
+				mask-image: none !important;
+				text-overflow: ellipsis;
+			}
+
+			> .urlbarView-action-btn {
+				padding-block: 2px !important;
+				border: none !important;
+				outline: none !important;
+				color: var(--button-text-color-primary);
+			}
+		}
+
+		&[has-url]:not([type$=tab]) > .urlbarView-row-inner > .urlbarView-no-wrap {
+			max-width: calc(70% - 2 * (var(--urlbarView-favicon-width) + (6px + 2px))) !important;
+		}
+
+		&[has-url] > .urlbarView-row-inner > .urlbarView-url {
+			margin-inline: revert !important;
+			line-height: 1.333 !important;
+		}
+
+		&[has-url]:not([type$=tab], [sponsored], [restyled-search]) .urlbarView-title-separator {
+			display: revert !important;
+		}
+
+		&[row-selectable]:not([selected]):hover {
+			color: var(--urlbarView-highlight-color);
+
+			.urlbarView-url {
+				color: inherit !important;
+			}
+		}
+
+		&:not([type=tip], [type=dynamic]) {
+			:root:not([uidensity=compact]) & {
+				min-height: 22px !important;
+			}
+		}
+
+		&[type=tip] {
+			padding-block: var(--urlbarView-item-block-padding) !important;
+
+			> .urlbarView-row-inner {
+				margin-inline-end: 0 !important;
+			}
+
+			> .urlbarView-button:not(:empty):not(.urlbarView-button-menu) {
+				padding-block: var(--space-xsmall) !important;
+				outline: none !important;
+				border-radius: var (--border-radius-small) !important;
+			}
+		}
+
+		&[rich-suggestion][type=search] {
+			:root:not([uidensity=compact]) & {
+				min-height: fit-content !important;
+			}
+		}
+
+		.urlbarView-favicon {
+			margin-inline-end: calc(var(--urlbarView-icon-margin-end) - var(--urlbarView-favicon-margin-start) - 1px) !important;
+		}
+
+		&[rich-suggestion] > .urlbarView-row-inner {
+			> .urlbarView-favicon {
+				width: 24px !important;
+				height: 24px !important;
+			}
+
+			> .urlbarView-row-body > :is(.urlbarView-row-body-description, .urlbarView-row-body-bottom) {
+				color: var(--urlbarView-highlight-color);
+			}
+		}
+
+		&[dynamicType=onboardTabToSearch] > .urlbarView-row-inner {
+			min-height: fit-content !important;
+
+			> .urlbarView-no-wrap > .urlbarView-favicon {
+				height: 16px !important;
+				min-width: 16px !important;
+
+				.urlbarView-row:hover & {
+					color: var(--urlbarView-highlight-color) !important;
+				}
+			}
+		}
+
+		&[has-action]:is([type=switchtab], [type=remotetab], [type=clipboard]) > .urlbarView-row-inner > .urlbarView-no-wrap > .urlbarView-action {
+			padding: 1px 5px !important;
+			margin-block: auto !important;
+			border: none !important;
+			background-image: none !important;
+			background-color: var(--theme-primary-active-color) !important;
+			color: var(--button-text-color-primary) !important;
+
+			&.urlbarView-userContext {
+				background-color: var(--identity-tab-color) !important;
+			}
+		}
+
+		> .urlbarView-button:not(.urlbarView-row[type=tip] > .urlbarView-button) {
+			background-color: transparent !important;
+			min-width: 16px !important;
+			min-height: 16px !important;
+
+			.urlbarView-row:is([row-selectable]:hover, [selected]) > &:not(:hover, [open]) {
+				color: var(--color-blue-05) !important;
+			}
+
+			&:is(:hover, [open]) {
+				color: revert !important;
+			}
+		}
+	}
+
+	[label]::before {
+		color: MenuText !important;
+	}
+
+	.urlbarView-title-separator::before {
+		content: "\2013" !important;
+	}
+
+	.urlbarView[noresults] > .urlbarView-body-outer > .urlbarView-body-inner > & {
+		padding: 0 !important;
+	}
+}
+
+.search-one-offs {
+	padding: var(--urlbar-icon-padding) !important;
+
+	> .search-panel-header {
+		min-height: var(--button-min-height) !important;
+
+		> .search-panel-one-offs-header-label {
+			padding-inline: var(--space-small) !important;
+		}
+	}
+
+	.searchbar-engine-one-off-item {
+		min-width: var(--button-min-height) !important;
+		height: var(--button-min-height) !important;
+		margin-inline: var(--urlbar-icon-padding) !important;
+
+		&:is(:not([selected]):hover, [selected]) {
+			background-color: var(--neptune-item-active-background) !important;
+		}
+	}
+}
+
+#identity-box:is([pageproxystate="valid"], [pageproxystate="invalid"]) > .identity-box-button,
+#urlbar-label-box {
+	padding-inline: var(--urlbar-icon-padding) !important;
+}
+
+@media not (-moz-bool-pref: "sidebar.verticalTabs") {
+	#identity-permission-box,
+	#notification-popup-box,
+	#tracking-protection-icon-container {
+		margin-inline-start: calc(-12px - 2 * var(--urlbar-icon-padding));
+		visibility: collapse;
+		opacity: 0;
+		transition: .2s ease;
+
+		&:is(.urlbar-input-container:hover &, [open]) {
+			margin-inline-start: 0;
+			visibility: visible;
+			opacity: 1;
+		}
+	}
+
+	.urlbar-page-action:not(#reader-mode-button[readeractive], #picture-in-picture-button[pipactive], #translations-button[translationsactive]) {
+		margin-inline-end: calc(-16px - 2 * var(--urlbar-icon-padding));
+		visibility: collapse;
+		transition: .2s ease;
+
+		&:is(.urlbar-input-container:hover &, [open]) {
+			margin-inline-end: 0;
+			visibility: visible;
+		}
+	}
+}
+
+#identity-box {
+	margin: 0 !important;
+	fill-opacity: 0.6 !important;
+
+	&[pageproxystate="valid"] > .identity-box-button {
+		background: none !important;
+
+		&:hover:not([open]) {
+			fill-opacity: 0.8;
+		}
+
+		&:is(:hover:active, [open]) {
+			fill-opacity: 1;
+		}
+	}
+}
+
+#notification-popup-box {
+	background: none !important;
+	height: auto !important;
+	fill-opacity: 0.6 !important;
+
+	> * {
+		height: calc(var(--urlbar-min-height) - 2 * var(--urlbar-icon-padding));
+	}
+
+	&:hover {
+		fill-opacity: 0.8 !important;
+	}
+
+	&:is(:hover:active, [open]) {
+		fill-opacity: 1 !important;
+	}
+}
+
+.urlbar-page-action,
+.urlbar-revert-button,
+.urlbar-go-button,
+.search-go-button {
+	background: none !important;
+	height: auto !important;
+	color: var(--neptune-button-field-color) !important;
+
+	&:not([disabled]):hover {
+		color: var(--neptune-button-field-hover-color) !important;
+	}
+
+	&:not([disabled]):is(:hover:active, [open]) {
+		color: revert !important;
+	}
+}
+
+#urlbar-zoom-button {
+	margin-inline: 2px !important;
+	padding-block: 2px !important;
+}
+
+.sharing-icon,
+#identity-icon,
+#permissions-granted-icon,
+#tracking-protection-icon,
+#tracking-protection-icon-box,
+#blocked-permissions-container > .blocked-permission-icon,
+.urlbarView-action-btn > img,
+#searchmode-switcher-icon,
+#searchmode-switcher-popup-search-settings-icon,
+.urlbar-input-container [id$="close"],
+.searchbar-search-icon,
+.searchbar-engine-one-off-item > .button-box > .button-icon {
+	width: 12px !important;
+	height: 12px !important;
+}

--- a/sidebery/sidebar.css
+++ b/sidebery/sidebar.css
@@ -5,6 +5,8 @@
   margin-bottom: var(--uc-tweak-rounded-corners-padding) !important;
   border-bottom-right-radius: var(--uc-tweak-rounded-corners-radius) !important;
   border-bottom-left-radius: var(--uc-tweak-rounded-corners-radius) !important;
+  box-shadow: none !important;
+  border: none !important;
 }
 
 #sidebar-title {
@@ -82,6 +84,7 @@
   ) !important;
   border-bottom: 0 !important;
   border-top-right-radius: var(--uc-tweak-rounded-corners-radius) !important;
+  border: none !important;
 }
 
 #sidebar-header #sidebar-switcher-target #sidebar-icon,
@@ -131,12 +134,142 @@
 .sidebar-panel {
   background-color: var(--lwt-accent-color) !important;
   color: var(--newtab-text-primary-color) !important;
+  padding: 0 var(--space-xsmall) !important;
+
+  moz-card {
+    border: none !important;
+    border-radius: var(--border-radius-small) !important;
+
+    h3 {
+      display: none;
+    }
+  }
+
+  > #manage-settings > a {
+    color: FieldText !important;
+  }
 }
 
 .sidebar-panel #search-box {
   -moz-appearance: none !important;
   background-color: var(--lwt-accent-color) !important;
   color: inherit !important;
+}
+
+.search-container {
+  height: var(--button-min-height) !important;
+
+  .search-icon {
+    background-size: 12px !important;
+    transform: scaleX(-1);
+  }
+
+  .clear-icon {
+    background-image: url(resource://content-accessible/searchfield-cancel.svg) !important;
+    background-size: 12px !important;
+    right: var(--space-xsmall) !important;
+    cursor: default !important;
+  }
+}
+
+#heading-wrapper {
+  padding-inline-start: var(--space-xsmall) !important;
+  gap: var(--space-xsmall) !important;
+
+  .chevron-icon {
+    min-height: var(--button-min-height) !important;
+    height: var(--button-min-height) !important;
+    background-image: url("chrome://global/skin/icons/arrow-down-12.svg") !important;
+
+    details[open] & {
+      background-image: url("chrome://global/skin/icons/arrow-up-12.svg") !important;
+    }
+  }
+}
+
+#moz-card-details > :is(summary, #content) {
+  padding: 0 !important;
+  cursor: default !important;
+}
+
+sidebar-tab-row {
+  --button-background-color-ghost-hover: var(--color-accent-primary-hover) !important;
+  --button-background-color-ghost-active: var(--color-accent-primary-active) !important;
+  --button-text-color-ghost-hover: var(--button-text-color-primary) !important;
+  --button-text-color-ghost-active: var(--button-text-color-primary) !important;
+  --fxview-text-primary-color: var(--button-text-color-primary) !important;
+  height: var(--button-min-height) !important;
+  border-radius: calc(var(--border-radius-small) - 2px) !important;
+}
+
+.fxview-tab-row-main {
+  background: none !important;
+  padding-block: 0 !important;
+  cursor: default !important;
+}
+
+.fxview-tab-row-button {
+  --button-size-icon: var(--size-item-small) !important;
+  --button-min-height: var(--button-min-height) !important;
+  --button-outer-padding-block: var(--space-xsmall) !important;
+  --button-outer-padding-inline: var(--space-xsmall) !important;
+}
+
+@layer input-common {
+  #input {
+    --input-width: 14px !important;
+    --input-height: 14px !important;
+    --input-margin-block-adjust: calc((1lh - var(--input-height)) / 2) !important;
+  }
+
+  .icon {
+    display: none;
+
+    + .text {
+      margin-inline-start: 0 !important;
+    }
+  }
+}
+
+moz-radio, moz-checkbox {
+  padding-block: var(--space-xsmall) !important;
+  border-color: var(--neptune-sidebar-border-color) !important;
+}
+
+treechildren::-moz-tree-row,
+treecol:not([hideheader="true"]),
+.tree-columnpicker-button {
+  min-height: var(--button-min-height) !important;
+}
+
+treechildren::-moz-tree-row(selected) {
+  background-color: var(--theme-primary-active-color) !important;
+}
+
+treechildren::-moz-tree-image(selected),
+treechildren::-moz-tree-twisty(selected),
+treechildren::-moz-tree-cell-text(selected) {
+  color: var(--button-text-color-primary) !important;
+}
+
+.content-shortcuts {
+  fill: var(--color-accent-primary) !important;
+  box-shadow: 0 0 5px var(--neptune-menu-shadow-color);
+}
+
+#header {
+  --icon-size-default: 12px !important;
+  padding-inline: 0 !important;
+
+  > select {
+    margin: 0 !important;
+  }
+}
+
+#tabbrowser-tabbox {
+  outline: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 /* Move statuspanel to the other side when sidebar is hovered so it doesn't get covered by sidebar */
@@ -200,4 +333,177 @@
     min-width: var(--uc-sidebar-hover-width) !important;
     transition-delay: 0ms !important;
   }
+}
+
+/*---------- Sidebar ----------*/
+#sidebar {
+	box-shadow: none !important;
+	border: none !important;
+}
+
+#sidebar-header {
+	font-size: 1.2em !important;
+	border: none !important;
+
+	#sidebar-switcher-target {
+		padding-block: 0 !important;
+		border-radius: var(--border-radius-small) !important;
+	}
+}
+
+#viewButton {
+	background-color: var(--neptune-item-background) !important;
+	border: none !important;
+	border-radius: 4px !important;
+
+	&[open] {
+		background-color: var(--neptune-item-active-background) !important;
+	}
+}
+
+.actions-list {
+	--button-min-height: var(--size-item-medium) !important;
+	--button-size-icon: var(--size-item-medium) !important;
+
+	> moz-button:not(.tools-overflow) {
+		--button-outer-padding-block: var(--space-xsmall) !important;
+
+		&:first-of-type {
+			--button-outer-padding-block-start: 0 !important;
+		}
+	}
+}
+
+.sidebar-panel {
+	--icon-size-default: 12px !important;
+	padding: 0 var(--space-xsmall) !important;
+
+	moz-card {
+		border: none !important;
+		border-radius: var(--border-radius-small) !important;
+
+		h3 {
+			display: none;
+		}
+	}
+
+	> #manage-settings > a {
+		color: FieldText !important;
+	}
+}
+
+.search-container {
+	height: var(--button-min-height) !important;
+
+	.search-icon {
+		background-size: 12px !important;
+		transform: scaleX(-1);
+	}
+
+	.clear-icon {
+		background-image: url(resource://content-accessible/searchfield-cancel.svg) !important;
+		background-size: 12px !important;
+		right: var(--space-xsmall) !important;
+		cursor: default !important;
+	}
+}
+
+#heading-wrapper {
+	padding-inline-start: var(--space-xsmall) !important;
+	gap: var(--space-xsmall) !important;
+
+	.chevron-icon {
+		min-height: var(--button-min-height) !important;
+		height: var(--button-min-height) !important;
+		background-image: url("chrome://global/skin/icons/arrow-down-12.svg") !important;
+
+		details[open] & {
+			background-image: url("chrome://global/skin/icons/arrow-up-12.svg") !important;
+		}
+	}
+}
+
+#moz-card-details > :is(summary, #content) {
+	padding: 0 !important;
+	cursor: default !important;
+}
+
+sidebar-tab-row {
+	--button-background-color-ghost-hover: var(--color-accent-primary-hover) !important;
+	--button-background-color-ghost-active: var(--color-accent-primary-active) !important;
+	--button-text-color-ghost-hover: var(--button-text-color-primary) !important;
+	--button-text-color-ghost-active: var(--button-text-color-primary) !important;
+	--fxview-text-primary-color: var(--button-text-color-primary) !important;
+	height: var(--button-min-height) !important;
+	border-radius: calc(var(--border-radius-small) - 2px) !important;
+}
+
+.fxview-tab-row-main {
+	background: none !important;
+	padding-block: 0 !important;
+	cursor: default !important;
+}
+
+.fxview-tab-row-button {
+	--button-size-icon: var(--size-item-small) !important;
+	--button-min-height: var(--button-min-height) !important;
+	--button-outer-padding-block: var(--space-xsmall) !important;
+	--button-outer-padding-inline: var(--space-xsmall) !important;
+}
+
+@layer input-common {
+	#input {
+		--input-width: 14px !important;
+		--input-height: 14px !important;
+		--input-margin-block-adjust: calc((1lh - var(--input-height)) / 2) !important;
+	}
+
+	.icon {
+		display: none;
+
+		+ .text {
+			margin-inline-start: 0 !important;
+		}
+	}
+}
+
+moz-radio, moz-checkbox {
+	padding-block: var(--space-xsmall) !important;
+	border-color: var(--neptune-sidebar-border-color) !important;
+}
+
+treechildren::-moz-tree-row,
+treecol:not([hideheader="true"]),
+.tree-columnpicker-button {
+	min-height: var(--button-min-height) !important;
+}
+
+treechildren::-moz-tree-row(selected) {
+	background-color: var(--theme-primary-active-color) !important;
+}
+
+treechildren::-moz-tree-image(selected),
+treechildren::-moz-tree-twisty(selected),
+treechildren::-moz-tree-cell-text(selected) {
+	color: var(--button-text-color-primary) !important;
+}
+
+.content-shortcuts {
+	fill: var(--color-accent-primary) !important;
+	box-shadow: 0 0 5px var(--neptune-menu-shadow-color);
+}
+
+#header {
+	--icon-size-default: 12px !important;
+	padding-inline: 0 !important;
+
+	> select {
+		margin: 0 !important;
+	}
+}
+
+#tabbrowser-tabbox {
+	outline: none !important;
+	border-radius: 0 !important;
+	box-shadow: none !important;
 }


### PR DESCRIPTION
Integrate Neptune's styles into Poseidon's existing structure and remove redundant Poseidon rules.

* **Navbar**: Merge rules from `src/neptune/userChome/neptune-navbar.css` into `core/toolbar/navbar.css`. Remove redundant Poseidon rules. Ensure Neptune’s aesthetic elements are integrated.
* **Urlbar**: Merge rules from `src/neptune/userChome/neptune-urlbar.css` into `core/toolbar/urlbar.css`. Ensure all Poseidon's core UI elements, specifically popover URL and Sidebery, remain fully functional. Remove redundant Poseidon rules. Ensure Neptune’s aesthetic elements are integrated.
* **Sidebar**: Merge rules from `src/neptune/userChome/neptune-sidebar.css` into `sidebery/sidebar.css`. Ensure all Poseidon's core UI elements, specifically popover URL and Sidebery, remain fully functional. Remove redundant Poseidon rules. Ensure Neptune’s aesthetic elements are integrated.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ranjef420/Poseidon/pull/8?shareId=0031619c-7367-44df-bc70-b3426adab748).